### PR TITLE
Make sure the proper store root tree is selected for export

### DIFF
--- a/Model/Export/Categories.php
+++ b/Model/Export/Categories.php
@@ -23,7 +23,8 @@ class Categories
         private CollectionFactory $collectionFactory,
         private StoreManagerInterface $storeManager,
         private Utils $utils
-    ) {}
+    ) {
+    }
 
     /**
      * @throws NoSuchEntityException
@@ -33,12 +34,22 @@ class Categories
     public function execute(int $storeId, array $attributes): array
     {
         array_unshift($attributes, 'category_code', 'parent_id');
+
+        $store = $this->storeManager->getStore($storeId);
+
+        // Get the root category to derive the path prefix
+        $rootCategoryId = (int) $store->getRootCategoryId();
+
         $collection = $this->collectionFactory->create();
         $collection->setStoreId($storeId);
         $collection->setProductStoreId($storeId);
         $collection->setLoadProductCount(false);
         $collection->addAttributeToSelect($attributes);
-        $collection->addAttributeToFilter('parent_id', ['neq' => 0]);
+
+        $collection->addPathsFilter("1/{$rootCategoryId}");
+
+        // Sort by level so parents are always in $parents[] before children
+        $collection->addAttributeToSort('level', 'ASC');
 
         $parents = [];
         $export = [];
@@ -47,7 +58,7 @@ class Categories
             $parents[$category->getId()] ??= $category;
             $parentCategory = $parents[$category->getParentId()] ?? null;
             $row = $this->utils->sanitizeData($category->toArray($attributes));
-            $row['store'] = $this->storeManager->getStore($storeId)->getCode();
+            $row['store'] = $store->getCode();
             $row['parent_code'] = $parentCategory?->getData('category_code');
             $export[] = $row;
         }


### PR DESCRIPTION
This will make sure only the categories for that store are exported.

If you have multiple stores with different root categories, the export did not properly select the correct root category but exported all root categories.

Setting the store_id for the collection, does not mean it gets filtered.
```
        $collection->setStoreId($storeId);
        $collection->setProductStoreId($storeId);
```