### PR TITLE
Fixed a bug where error message was not shown, improved the error message to be useful

### DIFF
--- a/Controller/Adminhtml/Export/CategoryPost.php
+++ b/Controller/Adminhtml/Export/CategoryPost.php
@@ -11,10 +11,10 @@ use Exception;
 use Magento\Backend\App\Action;
 use Magento\Framework\App\Action\HttpPostActionInterface;
 use Magento\Framework\Controller\Result\Redirect;
-use Magento\Framework\Exception\InputException;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Phrase;
 use Magento\Store\Model\Store;
+use Opengento\CategoryImportExport\Exception\InputException;
 use Opengento\CategoryImportExport\Model\Csv\Options;
 use Opengento\CategoryImportExport\Model\Export\ToCsv;
 use Opengento\CategoryImportExport\Model\Session\DownloadContext;
@@ -44,7 +44,7 @@ class CategoryPost extends Action implements HttpPostActionInterface
 
             $this->messageManager->addSuccessMessage(new Phrase('The export file is now ready for download.'));
         } catch (LocalizedException $e) {
-            $this->messageManager->addErrorMessage($e, $e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (Exception $e) {
             $this->messageManager->addExceptionMessage($e, new Phrase('Something went wrong while exporting the data.'));
         }

--- a/Exception/InputException.php
+++ b/Exception/InputException.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Copyright © OpenGento, All rights reserved.
+ * See LICENSE bundled with this library for license details.
+ */
+declare(strict_types=1);
+
+namespace Opengento\CategoryImportExport\Exception;
+
+use Magento\Framework\Phrase;
+use Magento\Framework\Exception\InputException as MagentoInputException;
+
+/**
+ * Exception to be thrown when there is an issue with the Input to a function call.
+ */
+class InputException extends MagentoInputException
+{
+    /**
+     * Creates an InputException for a missing required field.
+     */
+    public static function requiredField($fieldName, $entityId = null): MagentoInputException
+    {
+        if ($entityId) {
+            $messsage = new Phrase(
+                '"%fieldName" is required for entity "%entityId". Enter and try again.',
+                [
+                    'fieldName' => $fieldName,
+                    'entityId' => $entityId
+                ]
+            );
+        } else {
+            $messsage = new Phrase(
+                '"%fieldName" is required. Enter and try again.',
+                ['fieldName' => $fieldName]
+            );
+        }
+
+        return new self($messsage);
+    }
+}

--- a/Model/Csv/Options.php
+++ b/Model/Csv/Options.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 namespace Opengento\CategoryImportExport\Model\Csv;
 
 use Magento\Framework\App\RequestInterface;
-use Magento\Framework\Exception\InputException;
 use Magento\Framework\Phrase;
+use Opengento\CategoryImportExport\Exception\InputException;
 
 use function strlen;
 

--- a/Model/Export/Categories.php
+++ b/Model/Export/Categories.php
@@ -45,6 +45,10 @@ class Categories
         $collection->setProductStoreId($storeId);
         $collection->setLoadProductCount(false);
         $collection->addAttributeToSelect($attributes);
+        $collection->addAttributeToFilter([
+            ['attribute' => 'is_virtual_category', 'null' => true],
+            ['attribute' => 'is_virtual_category', 'eq'   => 0]
+        ]);
 
         $collection->addPathsFilter("1/{$rootCategoryId}");
 
@@ -55,11 +59,6 @@ class Categories
         $export = [];
         /** @var Category $category */
         foreach ($collection->getItems() as $category) {
-            // Skip virtual categories
-            if ($category->getData('is_virtual_category') ?? false) {
-                continue;
-            }
-
             $parents[$category->getId()] ??= $category;
             $parentCategory = $parents[$category->getParentId()] ?? null;
             $row = $this->utils->sanitizeData($category->toArray($attributes));

--- a/Model/Export/Categories.php
+++ b/Model/Export/Categories.php
@@ -9,10 +9,10 @@ namespace Opengento\CategoryImportExport\Model\Export;
 
 use Magento\Catalog\Model\Category;
 use Magento\Catalog\Model\ResourceModel\Category\CollectionFactory;
-use Magento\Framework\Exception\InputException;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Store\Model\StoreManagerInterface;
+use Opengento\CategoryImportExport\Exception\InputException;
 use Opengento\CategoryImportExport\Model\Utils;
 
 use function array_unshift;
@@ -55,6 +55,11 @@ class Categories
         $export = [];
         /** @var Category $category */
         foreach ($collection->getItems() as $category) {
+            // Skip virtual categories
+            if ($category->getData('is_virtual_category') ?? false) {
+                continue;
+            }
+
             $parents[$category->getId()] ??= $category;
             $parentCategory = $parents[$category->getParentId()] ?? null;
             $row = $this->utils->sanitizeData($category->toArray($attributes));

--- a/Model/Export/ToCsv.php
+++ b/Model/Export/ToCsv.php
@@ -9,11 +9,11 @@ namespace Opengento\CategoryImportExport\Model\Export;
 
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Exception\FileSystemException;
-use Magento\Framework\Exception\InputException;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\File\Csv;
 use Magento\Framework\Filesystem;
+use Opengento\CategoryImportExport\Exception\InputException;
 use Opengento\CategoryImportExport\Model\Csv\Options;
 
 use function array_keys;

--- a/Model/Import/Categories.php
+++ b/Model/Import/Categories.php
@@ -13,11 +13,11 @@ use Magento\Catalog\Model\CategoryFactory;
 use Magento\Catalog\Model\ResourceModel\Category\Collection;
 use Magento\Catalog\Model\ResourceModel\Category\CollectionFactory;
 use Magento\Framework\Exception\CouldNotSaveException;
-use Magento\Framework\Exception\InputException;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Phrase;
 use Magento\Store\Model\StoreManagerInterface;
+use Opengento\CategoryImportExport\Exception\InputException;
 use Opengento\CategoryImportExport\Model\Utils;
 
 class Categories

--- a/Model/Import/FromCsv.php
+++ b/Model/Import/FromCsv.php
@@ -7,11 +7,11 @@ namespace Opengento\CategoryImportExport\Model\Import;
 
 use Exception;
 use Magento\Framework\Exception\CouldNotSaveException;
-use Magento\Framework\Exception\InputException;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\File\Csv;
 use Magento\Framework\Phrase;
+use Opengento\CategoryImportExport\Exception\InputException;
 use Opengento\CategoryImportExport\Model\Csv\Options;
 
 use function array_combine;

--- a/Model/Utils.php
+++ b/Model/Utils.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
 
 namespace Opengento\CategoryImportExport\Model;
 
-use Magento\Framework\Exception\InputException;
+use Opengento\CategoryImportExport\Exception\InputException;
 use Opengento\CategoryImportExport\Model\Config\ExcludedFields;
 
 use function array_diff_key;
@@ -22,7 +22,7 @@ class Utils
      */
     public function sanitizeData(array $data): array
     {
-        $categoryCode = $data['category_code'] ?? throw InputException::requiredField('category_code');
+        $categoryCode = $data['category_code'] ?? throw InputException::requiredField('category_code', $data['entity_id'] ?? null);
         $data = array_diff_key($data, array_flip($this->excludedFields->get()));
 
         return ['category_code' => $categoryCode] + $data;


### PR DESCRIPTION
Corrected the call:

```
$this->messageManager->addErrorMessage($e, $e->getMessage());
```
Which takes the message as the first parameter, not the Exception.

Also added an InputException class to be able to show the entity id the export stops on and make it easier to fix for the end user.

I've also added a check for virtual categories, since they generally also don't have the category_code attribute set.