### PR TITLE
Add entity_id to the export, and remove entity_id and row_id from import data if present

### DIFF
--- a/Model/Export/Categories.php
+++ b/Model/Export/Categories.php
@@ -33,7 +33,7 @@ class Categories
      */
     public function execute(int $storeId, array $attributes): array
     {
-        array_unshift($attributes, 'category_code', 'parent_id');
+        array_unshift($attributes, 'category_code', 'parent_id', 'entity_id');
 
         $store = $this->storeManager->getStore($storeId);
 

--- a/Model/Export/Categories.php
+++ b/Model/Export/Categories.php
@@ -58,6 +58,7 @@ class Categories
             $parents[$category->getId()] ??= $category;
             $parentCategory = $parents[$category->getParentId()] ?? null;
             $row = $this->utils->sanitizeData($category->toArray($attributes));
+            $row['entity_id'] = $category->getId();
             $row['store'] = $store->getCode();
             $row['parent_code'] = $parentCategory?->getData('category_code');
             $export[] = $row;

--- a/Model/Import/Categories.php
+++ b/Model/Import/Categories.php
@@ -56,11 +56,6 @@ class Categories
 
         try {
             foreach ($rows as $row) {
-                // Unset the entity_id and/or row_id if they exist.
-                // Magento needs to create their own.
-                unset($row['entity_id']);
-                unset($row['row_id']);
-
                 $category = $collection->getItemByColumnValue('category_code', $row['category_code'])
                     ?? $this->categoryFactory->create();
                 $category->addData($row);

--- a/Model/Import/Categories.php
+++ b/Model/Import/Categories.php
@@ -56,6 +56,11 @@ class Categories
 
         try {
             foreach ($rows as $row) {
+                // Unset the entity_id and/or row_id if they exist.
+                // Magento needs to create their own.
+                unset($row['entity_id']);
+                unset($row['row_id']);
+
                 $category = $collection->getItemByColumnValue('category_code', $row['category_code'])
                     ?? $this->categoryFactory->create();
                 $category->addData($row);

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -9,7 +9,7 @@
     <default>
         <catalog>
             <category_import_export>
-                <exclude_fields>created_at,created_in,parent_id,store_id,store,updated_at,updated_in</exclude_fields>
+                <exclude_fields>entity_id,row_id,created_at,created_in,parent_id,store_id,store,updated_at,updated_in</exclude_fields>
                 <exclude_attributes>image</exclude_attributes>
             </category_import_export>
         </catalog>


### PR DESCRIPTION
This may be specific to my use case, exporting for use in a PIM but I can imagine others find the entity_id useful in the export as well.